### PR TITLE
Add optimisations for bubbles

### DIFF
--- a/lib/bubble_clicker_web/live/bubble_grid_live/index.ex
+++ b/lib/bubble_clicker_web/live/bubble_grid_live/index.ex
@@ -1,5 +1,5 @@
 defmodule BubbleClickerWeb.BubbleGridLive.Index do
-  use Phoenix.LiveView
+  use BubbleClickerWeb, :live_view
 
   def mount(_params, _session, socket) do
     grid_size = 200

--- a/lib/bubble_clicker_web/live/bubble_grid_live/index.ex
+++ b/lib/bubble_clicker_web/live/bubble_grid_live/index.ex
@@ -2,7 +2,7 @@ defmodule BubbleClickerWeb.BubbleGridLive.Index do
   use Phoenix.LiveView
 
   def mount(_params, _session, socket) do
-    grid_size = 100
+    grid_size = 200
 
     bubbles = generate_bubbles(grid_size)
     bubbles_grid = generate_grid_from_bubbles_v2(bubbles)
@@ -15,32 +15,25 @@ defmodule BubbleClickerWeb.BubbleGridLive.Index do
     {:ok, socket}
   end
 
-  def handle_event("pop", %{"column" => column, "row" => row}, socket) do
+  def handle_event("pop", %{"id" => id, "column" => column, "row" => row}, socket) do
     row_number = String.to_integer(row)
     column_number = String.to_integer(column)
 
-    updated_bubbles = pop_bubble(socket.assigns.bubbles, row_number, column_number)
-    bubbles_grid = generate_grid_from_bubbles_v2(updated_bubbles)
-
-    edited_cell =
-      bubbles_grid
-      |> Enum.find(fn %{column_index: column_index, row_index: row_index} = _item ->
-        column_index === column_number && row_index === row_number
-      end)
+    generated_bubble = %{
+      id: id,
+      value: true,
+      column_index: column_number,
+      row_index: row_number
+    }
 
     socket =
-      assign(socket, :bubbles, updated_bubbles)
-      |> stream_insert(:bubbles_grid, edited_cell, at: edited_cell.id)
+      stream_insert(socket, :bubbles_grid, generated_bubble, at: generated_bubble.id)
 
     {:noreply, socket}
   end
 
   defp generate_bubbles(size) do
     List.duplicate(false, size) |> Enum.map(fn _x -> List.duplicate(false, size) end)
-  end
-
-  defp pop_bubble(bubbles, row, column) do
-    bubbles |> List.update_at(row, &List.update_at(&1, column, fn _ -> true end))
   end
 
   defp generate_grid_from_bubbles_v2(bubbles) do

--- a/lib/bubble_clicker_web/live/bubble_grid_live/index.html.heex
+++ b/lib/bubble_clicker_web/live/bubble_grid_live/index.html.heex
@@ -14,7 +14,7 @@
   <div
     :for={{dom_id, cell} <- @streams.bubbles_grid}
     id={dom_id}
-    class={"p-2 #{if cell.value, do: "bg-black", else: "bg-blue-500"}"}
+    class={"p-2 select-none #{if cell.value, do: "bg-black", else: "bg-blue-500"}"}
     phx-click="pop"
     phx-value-row={cell.row_index}
     phx-value-column={cell.column_index}

--- a/lib/bubble_clicker_web/live/bubble_grid_live/index.html.heex
+++ b/lib/bubble_clicker_web/live/bubble_grid_live/index.html.heex
@@ -14,8 +14,8 @@
   <div
     :for={{dom_id, cell} <- @streams.bubbles_grid}
     id={dom_id}
-    class={"p-2 select-none #{if cell.value, do: "bg-black", else: "bg-blue-500"}"}
-    phx-click="pop"
+    class={"p-2 select-none #{if cell.value, do: "!bg-black", else: "bg-blue-500"}"}
+    phx-click={JS.push("pop") |> JS.add_class("!bg-black")}
     phx-value-row={cell.row_index}
     phx-value-column={cell.column_index}
     phx-value-id={cell.id}

--- a/lib/bubble_clicker_web/live/bubble_grid_live/index.html.heex
+++ b/lib/bubble_clicker_web/live/bubble_grid_live/index.html.heex
@@ -18,6 +18,7 @@
     phx-click="pop"
     phx-value-row={cell.row_index}
     phx-value-column={cell.column_index}
+    phx-value-id={cell.id}
   >
   </div>
 </div>


### PR DESCRIPTION
- Make bubbles non draggable (resulting in some weird behaviour when clicking too quickly, and undesirable)
- Create only the bubble we want to send downstream when cell "popped". Was previously editing whole list (so creating a whole new list, and selecting + sending only the edited cell).
- Optimistically show click changes with phoenix JS utility.